### PR TITLE
Fix: Reverse order of upcoming shows

### DIFF
--- a/lib/contentful/pages/home.ts
+++ b/lib/contentful/pages/home.ts
@@ -45,7 +45,7 @@ export async function getHomePage(limit = LIMITS.SHOWS) {
         where: { 
           date_gt: "${dayjs().format("YYYY-MM-DD")}"
         },
-        order: date_DESC
+        order: date_ASC
       ) {
         items {
           title

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,15 +610,10 @@ camelcase-css@^2.0.1:
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
-caniuse-lite@^1.0.30001264:
-  version "1.0.30001265"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz#0613c9e6c922e422792e6fcefdf9a3afeee4f8c3"
-  integrity sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==
-
-caniuse-lite@^1.0.30001406:
-  version "1.0.30001506"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz#35bd814b310a487970c585430e9e80ee23faf14b"
-  integrity sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==
+caniuse-lite@^1.0.30001264, caniuse-lite@^1.0.30001406:
+  version "1.0.30001584"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001584.tgz"
+  integrity sha512-LOz7CCQ9M1G7OjJOF9/mzmqmj3jE/7VOmrfw6Mgs0E8cjOsbRXQJHsPBfmBOXDskXKrHLyyW3n7kpDW/4BsfpQ==
 
 chalk@^2.0.0:
   version "2.4.2"


### PR DESCRIPTION
The shows being displayed in the “Upcoming Shows” section are in the wrong order. The section should highlight the next upcoming shows in chronological order, instead it’s doing the reverse.