### PR TITLE
Fix: Re-sort upcoming shows order

### DIFF
--- a/lib/contentful/pages/home.ts
+++ b/lib/contentful/pages/home.ts
@@ -106,6 +106,11 @@ export async function getHomePage(limit = LIMITS.SHOWS) {
     .filter((show) => show.mixcloudLink)
     .splice(0, 8);
 
+  const upcomingShows = extractCollection<ShowInterface>(data, "upcomingShows")
+    .sort(sort.date_ASC)
+    .filter((show) => dayjs(show.date).isAfter(today))
+    .splice(0, 16);
+
   return {
     featuredArticles: extractCollection<ArticleInterface>(
       data,
@@ -113,7 +118,7 @@ export async function getHomePage(limit = LIMITS.SHOWS) {
     ),
     featuredShows: extractCollection<ShowInterface>(data, "featuredShows"),
     latestShows,
-    upcomingShows: extractCollection<ShowInterface>(data, "upcomingShows"),
+    upcomingShows,
     latestArticles: extractCollection<ArticleInterface>(data, "latestArticles"),
   };
 }

--- a/lib/contentful/pages/home.ts
+++ b/lib/contentful/pages/home.ts
@@ -45,7 +45,7 @@ export async function getHomePage(limit = LIMITS.SHOWS) {
         where: { 
           date_gt: "${dayjs().format("YYYY-MM-DD")}"
         },
-        order: date_ASC
+        order: date_DESC
       ) {
         items {
           title

--- a/lib/contentful/pages/home.ts
+++ b/lib/contentful/pages/home.ts
@@ -45,7 +45,7 @@ export async function getHomePage(limit = LIMITS.SHOWS) {
         where: { 
           date_gt: "${dayjs().format("YYYY-MM-DD")}"
         },
-        order: date_DESC
+        order: date_ASC
       ) {
         items {
           title

--- a/views/UpcomingShows.tsx
+++ b/views/UpcomingShows.tsx
@@ -11,23 +11,7 @@ const UpcomingShows = ({
   shows: ShowInterface[];
   heading?: string;
 }) => {
-  // Get the current date
-  const currentDate = new Date();
-
-  // Filter out past shows
-  const upcomingShows = shows.filter((show) => {
-    const showDate = new Date(show.date);
-    return showDate > currentDate;
-  });
-
-  // Sort upcoming shows in ascending order
-  upcomingShows.sort((a, b) => {
-    const dateA = new Date(a.date).getTime();
-    const dateB = new Date(b.date).getTime();
-    return dateA - dateB;
-  });
-
-  if (upcomingShows.length < 1) return;
+  if (shows.length < 1) return;
 
   return (
     <div className="overflow-hidden bg-orokoBlue border-b-2 border-black">
@@ -43,7 +27,7 @@ const UpcomingShows = ({
       </div>
 
       <Slider>
-        {upcomingShows.map((show, idx) => (
+        {shows.map((show, idx) => (
           <Slider.Card
             imageUrl={show.coverImage.url}
             title={show.title}

--- a/views/UpcomingShows.tsx
+++ b/views/UpcomingShows.tsx
@@ -11,7 +11,23 @@ const UpcomingShows = ({
   shows: ShowInterface[];
   heading?: string;
 }) => {
-  if (shows.length < 1) return;
+  // Get the current date
+  const currentDate = new Date();
+
+  // Filter out past shows
+  const upcomingShows = shows.filter((show) => {
+    const showDate = new Date(show.date);
+    return showDate > currentDate;
+  });
+
+  // Sort upcoming shows in ascending order
+  upcomingShows.sort((a, b) => {
+    const dateA = new Date(a.date).getTime();
+    const dateB = new Date(b.date).getTime();
+    return dateA - dateB;
+  });
+
+  if (upcomingShows.length < 1) return;
 
   return (
     <div className="overflow-hidden bg-orokoBlue border-b-2 border-black">
@@ -27,7 +43,7 @@ const UpcomingShows = ({
       </div>
 
       <Slider>
-        {shows.map((show, idx) => (
+        {upcomingShows.map((show, idx) => (
           <Slider.Card
             imageUrl={show.coverImage.url}
             title={show.title}


### PR DESCRIPTION
- Applied sorting directly within the upcoming shows section to ensure chronological order.
- Retained the original GraphQL query sorting by date in descending order (date_DESC) to maintain consistency with the server-side data retrieval.
- Implemented sorting of shows in ascending order based on their dates using JavaScript's `Date` object.
- Ensured proper display of upcoming shows from oldest to newest while filtering out past shows.